### PR TITLE
Improved parsing of the last updated date

### DIFF
--- a/src/commands/repo.js
+++ b/src/commands/repo.js
@@ -74,8 +74,8 @@ module.exports.run = async(client, message, args) => {
 	let Updated = "No data"
 	
 	await axios.get(encodeURI(`https://ktane.timwi.de/ManualLastUpdated/${inputmodule.Name}.html`)).then(async(resp) =>{
-		let splitted = resp.data.split(' ')
-		Updated = `${splitted[2]}/${months.indexOf(splitted[1])+1}/${splitted[4]}`
+		let LastUpdatedDate = new Date(resp)
+		Updated = `${LastUpdatedDate.getUTCFullYear()}/${LastUpdatedDate.getUTCMonth()+1}/${LastUpdatedDate.getUTCDate()}`
 	}).catch()
 	
     //making sure the manuals fit into the embed


### PR DESCRIPTION
I used `LastUpdatedDate.getUTFFullYear()` etc... you can just remove `UTC` if you want it in the local timezone for the bot's server. I just thought it would be better as UTC.