### PR TITLE
Duplicate messages

### DIFF
--- a/src/commands/faq.js
+++ b/src/commands/faq.js
@@ -2,8 +2,9 @@ const { questions, categories } = require('../questions.js')
 const { CreateAPIMessage } = require('../utils.js');
 const { Bot } = require('../main.js');
 
-const disabledServers = ['702194117030969344'];
-const whiteListedChannels = [{serverId: '702194117030969344', allowedChannels: ['702506351305293956']}]
+const disabledServers = ['702194117030969344', '160061833166716928'];
+const whiteListedChannels = [{serverId: '702194117030969344', allowedChannels: ['702506351305293956']},
+                             {serverId: '160061833166716928', allowedChannels: ['394275199509594113']}]
 
 module.exports.run = async (client, message, args) => {
     const validator = validateCommand(message);
@@ -133,7 +134,6 @@ function validateCommand(interaction)
         const validChannel = whiteListedChannels.find(obj => obj.serverId == guildId);
         if(validChannel)
         {
-            
             const channelString = validChannel.allowedChannels.map(id => `https://discordapp.com/channels/${guildId}/${id}`).join(', ');
             return `The bot is disabled from running faq commands in this channel. This is only allowed in the following channels: ${channelString}`;
         }


### PR DESCRIPTION
Some answers are very long, so long that they require to be sent within multiple messages. There is a bot within the ktane server that tries to prevent spam. If an account sends too many messages within a small time frame, the messages will be deleted. This means that some questions, such as "How do I create my manual" to be useless.

Since it's best to have this bot send questions within the server, I made it so if the bot is asked a questions that has been asked recently (this is true if the question have been found within X amount of messages within the channel),  instead printing out the same answer, it will link to the previous answer. The mods of the ktane server would still need to whitelist the bot so it can write the long answers.

Although the main functionality is there, there are some things needed to be done / talked about befor this pr is approved:

- I added [messageLimit and messageFluff](https://github.com/BlckHawker/ktanecord/blob/duplicate-messages/src/commands/faq.js#L166-L167) as parameters to see how many messages back the bot should check for the answer. idk if they should be set in the `config` file. Or if they should be parameters for a specific guild. Like the ktane server can have a limit of 10, while the bot test server has one for 0. 

- I added the ability of the faq commands not working in any channel except whitelisted ones.  I originally tried [this message](https://discord.com/channels/702194117030969344/702197135147270226/1318819800004427827) with the ["test the bot" channel](https://discord.com/channels/702194117030969344/702506351305293956)  being replaced with the ["bot-test" channel](https://discord.com/channels/702194117030969344/702197135147270226) . I tried this in the ["test the bot" channel](https://discord.com/channels/702194117030969344/702506351305293956), but got the error: `DiscordAPIError: Missing Access`. This should be fine as long as it's gaurnteed all whitelisted channels are public, but idk if we want to assume that. Also wasn't sure if this is something that will be parameterized by people who are not devs.